### PR TITLE
fix: prevent SSRF in product scraper and restrict sensitive data logging to development

### DIFF
--- a/src/OpenWish.Application/Services/ProductService.cs
+++ b/src/OpenWish.Application/Services/ProductService.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Sockets;
 using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using Microsoft.Extensions.Logging;
@@ -26,11 +28,65 @@ public partial class ProductService : IProductService
         _logger = logger;
     }
 
+    /// <summary>
+    /// Validates that a URL is safe to fetch: must use http/https and must not target
+    /// loopback addresses, link-local ranges, or private (RFC-1918/RFC-4193) networks.
+    /// </summary>
+    private static async Task<bool> IsSafeUrlAsync(Uri uri)
+    {
+        if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            return false;
+
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await Dns.GetHostAddressesAsync(uri.DnsSafeHost);
+        }
+        catch
+        {
+            return false;
+        }
+
+        foreach (var address in addresses)
+        {
+            if (IPAddress.IsLoopback(address))
+                return false;
+
+            var bytes = address.GetAddressBytes();
+
+            if (address.AddressFamily == AddressFamily.InterNetwork)
+            {
+                // 10.0.0.0/8
+                if (bytes[0] == 10) return false;
+                // 172.16.0.0/12
+                if (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) return false;
+                // 192.168.0.0/16
+                if (bytes[0] == 192 && bytes[1] == 168) return false;
+                // 169.254.0.0/16  (link-local / cloud metadata)
+                if (bytes[0] == 169 && bytes[1] == 254) return false;
+            }
+            else if (address.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                // ::1 is covered by IsLoopback(); also block fc00::/7 (ULA) and fe80::/10 (link-local)
+                if (bytes[0] == 0xfc || bytes[0] == 0xfd) return false;
+                if (bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0x80) return false;
+            }
+        }
+
+        return true;
+    }
+
     public async Task<ProductModel?> TryScrapeProductFromUrl(string url)
     {
         try
         {
-            var response = await _client.GetAsync(url);
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || !await IsSafeUrlAsync(uri))
+            {
+                _logger.LogWarning("Rejected unsafe or invalid URL for product scrape: {Url}", url);
+                return null;
+            }
+
+            var response = await _client.GetAsync(uri);
             response.EnsureSuccessStatusCode();
 
             var html = await response.Content.ReadAsStringAsync();

--- a/src/OpenWish.Web/Program.cs
+++ b/src/OpenWish.Web/Program.cs
@@ -62,10 +62,14 @@ var connectionString = builder.Configuration.GetConnectionString("OpenWish")
 
 builder.Services.AddDbContextFactory<ApplicationDbContext>(options =>
 {
-    options.UseNpgsql(connectionString)
+    var dbOptions = options.UseNpgsql(connectionString)
         // HMM... https://github.com/dotnet/efcore/issues/34431
-        .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
-        .EnableSensitiveDataLogging();
+        .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
+
+    if (builder.Environment.IsDevelopment())
+    {
+        dbOptions.EnableSensitiveDataLogging();
+    }
 });
 
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();


### PR DESCRIPTION
## Summary

Fixes two security vulnerabilities identified in the codebase.

## Changes

### 1. SSRF Prevention in `ProductService` (Critical)

`ProductService.TryScrapeProductFromUrl` accepted any user-supplied URL and made a server-side HTTP request without validation. An authenticated user could exploit this to:
- Probe internal services (e.g., `http://localhost/admin`)
- Access cloud metadata endpoints (e.g., `http://169.254.169.254/`)
- Scan private RFC-1918 networks

**Fix:** Added `IsSafeUrlAsync()` which, before any HTTP request is made:
- Enforces http/https schemes only
- Resolves the hostname via DNS and rejects addresses that are:
  - Loopback (127.x.x.x / ::1)
  - Private IPv4: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
  - Link-local: 169.254.0.0/16 (cloud metadata)
  - IPv6 ULA (fc00::/7) and link-local (fe80::/10)

### 2. Sensitive Data Logging Restricted to Development

`EnableSensitiveDataLogging()` was called unconditionally, causing EF Core to log SQL parameter values (potentially including PII/credentials) in all environments including production.

**Fix:** Wrapped the call in an `IsDevelopment()` guard.

## Files Modified

- `src/OpenWish.Application/Services/ProductService.cs`
- `src/OpenWish.Web/Program.cs`